### PR TITLE
set protocol based on rc_keymap

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -1,0 +1,4 @@
+cc_binary {
+    name: "ir-keytable",
+    srcs: ["keytable.c"],
+}

--- a/Android.bp
+++ b/Android.bp
@@ -1,4 +1,5 @@
 cc_binary {
     name: "ir-keytable",
+    proprietary: true,
     srcs: ["keytable.c"],
 }

--- a/Android.mk
+++ b/Android.mk
@@ -1,8 +1,0 @@
-LOCAL_PATH:= $(call my-dir)
-
-include $(CLEAR_VARS)
-
-LOCAL_SRC_FILES := keytable.c
-LOCAL_MODULE := ir-keytable
-LOCAL_C_INCLUDES := external/v4l-utils
-include $(BUILD_EXECUTABLE)

--- a/keytable.c
+++ b/keytable.c
@@ -83,11 +83,6 @@ static const char doc[] = {
 
 };
 
-static const char args_doc[] = {
-    "--device [/dev/input/event* device]\n"
-    "--sysdev [ir class (f. ex. rc0)]\n"
-    "[for using the rc0 sysdev]"};
-
 struct input_keymap_entry_v2 {
 #define KEYMAP_BY_INDEX (1 << 0)
     u_int8_t  flags;
@@ -236,7 +231,6 @@ static int parse_code(char *string)
 const char *argp_program_version = "IR keytable control version " V4L_UTILS_VERSION;
 const char *argp_program_bug_address = "Mauro Carvalho Chehab <m.chehab@samsung.com>";
 
-static int print_version = 0;
 static const struct option long_options[] = {
     {"verbose", no_argument, 0, 'v'},
     {"clear",   no_argument, 0, 'c'},
@@ -480,10 +474,8 @@ static int parse_opt(int argc, char* argv[])
     long key;
     int rc;
     int c;
-    int digit_optind = 0;
 
     while (1) {
-        int this_option_optind = optind ? optind : 1;
         int option_index = 0;
         c = getopt_long(argc, argv, "vtcD:P:Ad:s:rw:a:k:p:d:f:V",long_options, &option_index);
             if (c == -1)
@@ -1294,7 +1286,7 @@ static void test_event(int fd)
             return;
         }
 
-        for (i = 0; i < rd / sizeof(struct input_event); i++) {
+        for (i = 0; i < rd / (int) sizeof(struct input_event); i++) {
             printf(_("%ld.%06ld: event type %s(0x%02x)"),
                 ev[i].time.tv_sec, ev[i].time.tv_usec,
                 get_event_name(events_type, ev[i].type), ev[i].type);


### PR DESCRIPTION
Ok, to start, I have not really looked into how to do the whole PR thing (so I know this isn't formatted correctly, etc and if there's been an issues section, I'd have posted this in it instead.)

That said, there is a major issue with the current implementation of setting up an IR remote and that is there's no easy way (that I've found) to "set and forget" the protocol. Adding one line to /system/etc/init.d/02remote takes care of that issue.
````
       if [ -f /boot/rc_keymap ]; then
            /vendor/bin/ir-keytable -c -w /boot/rc_keymap
+++         ir-keytable -p `head -n 1 /boot/rc_keymap|cut -d " " -f 4|tr A-Z a-z`
        fi
````
The first line of my rc_keymap reads **"table sony, type: SONY"** so it now sets the protocol to sony at boot. Most of the supplied keymaps have UNKNOWN and for those, this change wouldn't do/affect anything (ir-keytable will simply thor an error message and move on.) Without some method of changing the protocol, it'd be stuck on the rc-6 & licr protocols.